### PR TITLE
Remove dependencies on BinaryData.h

### DIFF
--- a/src/WebProcessor.cpp
+++ b/src/WebProcessor.cpp
@@ -9,15 +9,16 @@
 
 namespace imagiro {
 
-    WebProcessor::WebProcessor(juce::String currentVersion, juce::String productSlug)
-            : Processor(currentVersion, productSlug)
+    WebProcessor::WebProcessor(std::function<juce::String()> getParametersYAMLString, juce::String currentVersion, juce::String productSlug)
+            : Processor(getParametersYAMLString, currentVersion, productSlug)
     {
         init();
     }
 
     WebProcessor::WebProcessor(const juce::AudioProcessor::BusesProperties &ioLayouts,
+                               std::function<juce::String()> getParametersYAMLString,
                                juce::String currentVersion, juce::String productSlug)
-            : Processor(ioLayouts, currentVersion, productSlug)
+            : Processor(ioLayouts, getParametersYAMLString, currentVersion, productSlug)
     {
         init();
     }

--- a/src/WebProcessor.cpp
+++ b/src/WebProcessor.cpp
@@ -49,11 +49,11 @@ namespace imagiro {
     }
 
     void WebProcessor::init() {
-        addUIAttachment(std::make_unique<ParameterAttachment>(*this, webView));
-        addUIAttachment(std::make_unique<PresetAttachment>(*this, webView));
-        addUIAttachment(std::make_unique<PluginInfoAttachment>(*this, webView));
-        addUIAttachment(std::make_unique<AuthAttachment>(*this, webView));
-        addUIAttachment(std::make_unique<FileIOAttachment>(*this, webView));
+        addUIAttachment(std::make_unique<ParameterAttachment>(*this, webViewManager));
+        addUIAttachment(std::make_unique<PresetAttachment>(*this, webViewManager));
+        addUIAttachment(std::make_unique<PluginInfoAttachment>(*this, webViewManager));
+        addUIAttachment(std::make_unique<AuthAttachment>(*this, webViewManager));
+        addUIAttachment(std::make_unique<FileIOAttachment>(*this, webViewManager));
     }
 
     void WebProcessor::addUIAttachment(WebUIAttachment& attachment) {

--- a/src/WebProcessor.h
+++ b/src/WebProcessor.h
@@ -15,9 +15,9 @@ class WebUIAttachment;
 
 class WebProcessor : public Processor {
 public:
-    WebProcessor(juce::String currentVersion = "1.0.0", juce::String productSlug = "");
+    WebProcessor(std::function<juce::String()> getParametersYAMLString, juce::String currentVersion = "1.0.0", juce::String productSlug = "");
     WebProcessor(const juce::AudioProcessor::BusesProperties& ioLayouts,
-              juce::String currentVersion = "1.0.0", juce::String productSlug = "");
+              std::function<juce::String()> getParametersYAMLString, juce::String currentVersion = "1.0.0", juce::String productSlug = "");
 
     WebViewManager& getWebViewManager() { return webViewManager; }
     juce::AudioProcessorEditor* createEditor() override;

--- a/src/WebUIPluginEditor.h
+++ b/src/WebUIPluginEditor.h
@@ -88,8 +88,8 @@ private:
     ChocBrowserComponent browser;
     WebUIDebugToolbar debugToolbar;
 
+
     std::unique_ptr<juce::FileChooser> fileChooser;
 };
 
 }
-

--- a/src/WebViewManager.h
+++ b/src/WebViewManager.h
@@ -5,7 +5,7 @@
 #include <choc/gui/choc_WebView.h>
 #include <juce_core/juce_core.h>
 #include <juce_audio_processors/juce_audio_processors.h>
-#include "ChocServer.h"
+#include "ChocAssetsServer.h"
 #include <imagiro_util/imagiro_util.h>
 
 #pragma once
@@ -20,7 +20,8 @@ namespace imagiro {
         void addListener(Listener* l) {listeners.add(l);}
         void removeListener(Listener* l) {listeners.remove(l);}
 
-        WebViewManager() {
+        WebViewManager(ChocAssetsServer& server) : server(server) {
+
             preparedWebview = createWebView();
             setupWebview(*preparedWebview);
 
@@ -135,7 +136,7 @@ namespace imagiro {
         std::optional<std::string> htmlToSet;
         std::optional<std::string> currentURL;
 
-        ChocServer server;
+        ChocAssetsServer& server;
 
         moodycamel::ReaderWriterQueue<std::string> jsEvalQueue {2048};
     };

--- a/src/attachment/ParameterAttachment.cpp
+++ b/src/attachment/ParameterAttachment.cpp
@@ -168,4 +168,3 @@ choc::value::Value imagiro::ParameterAttachment::getParameterSpecValue(imagiro::
     paramSpec.setMember("range", range);
     return paramSpec;
 }
-

--- a/src/attachment/ParameterAttachment.h
+++ b/src/attachment/ParameterAttachment.h
@@ -5,7 +5,6 @@
 #pragma once
 #include "WebUIAttachment.h"
 #include <imagiro_processor/imagiro_processor.h>
-#include <farbot/fifo.hpp>
 
 namespace imagiro {
     class ParameterAttachment : public WebUIAttachment, public Parameter::Listener {


### PR DESCRIPTION
As discussed on Discord, let's remove the hard dependency on `BinaryData.h`, since we don't know how the underlying plugin is actually building its assets. As per [the JUCE CMake API](https://github.com/juce-framework/JUCE/blob/master/docs/CMake%20API.md#juce_add_binary_data), `juce_add_binary_data` can build an assets target with both a custom header, and a custom name under a custom namespace.

The way it works now is that the WebProcessor now defines two virtual methods:

```cpp
    virtual const char* getNamedResource (const char* resourceNameUTF8, int& dataSizeInBytes) = 0;
    virtual const char* getNamedResourceOriginalFilename (const char* resourceNameUTF8) = 0;
```

And those can then be overridden in the Processor subclass. Realistically all you need to do in the subclass is call the same methods on your assets target, for me I'm doing:

```cpp
            const char * getNamedResource(const char *resourceNameUTF8, int &dataSizeInBytes) override {
                return timeoffaudio::dime::assets::getNamedResource(resourceNameUTF8, dataSizeInBytes);
            }

            const char * getNamedResourceOriginalFilename(const char *resourceNameUTF8) override {
                return timeoffaudio::dime::assets::getNamedResourceOriginalFilename(resourceNameUTF8);
            }
```

These are then passed as lambdas to the ChocServer (which I renamed to ChocAssetsServer for extra clarity).

The second commit is basically a companion change to https://github.com/augustpemberton/imagiro_processor/pull/1