### PR TITLE
Cleanup ignoreCallbackParam in ParameterAttachment

### DIFF
--- a/src/attachment/ParameterAttachment.cpp
+++ b/src/attachment/ParameterAttachment.cpp
@@ -30,7 +30,6 @@ void imagiro::ParameterAttachment::addBindings() {
 
                 auto param = processor.getParameter(paramID);
                 if (param) {
-//                    juce::ScopedValueSetter<Parameter*> svs (ignoreCallbackParam, param);
                     param->setValueNotifyingHost(newValue01);
                 }
 
@@ -121,8 +120,7 @@ void imagiro::ParameterAttachment::addBindings() {
 }
 
 void imagiro::ParameterAttachment::parameterChangedSync(imagiro::Parameter *param) {
-    if (ignoreCallbackParam != param)
-        sendStateToBrowser(param);
+    sendStateToBrowser(param);
 }
 
 void imagiro::ParameterAttachment::sendStateToBrowser(imagiro::Parameter *param) {

--- a/src/attachment/ParameterAttachment.h
+++ b/src/attachment/ParameterAttachment.h
@@ -24,7 +24,5 @@ namespace imagiro {
         choc::value::Value getAllParameterSpecValue();
 
         static choc::value::Value getParameterSpecValue(Parameter* param);
-
-        Parameter* ignoreCallbackParam {nullptr};
     };
 } // namespace imagiro


### PR DESCRIPTION
As discussed on Discord. I believe this was broken since ignoreCallbackParam was effectively always `nullptr`.

We agreed that the callback ignoring flag logic should be handled in the UI somewhere so the `ParameterAttachment` will always send updates to the webview when available.