### PR TITLE
Add a URL-opening action to WebViewManager

### DIFF
--- a/src/WebViewManager.cpp
+++ b/src/WebViewManager.cpp
@@ -58,6 +58,12 @@ namespace imagiro {
                       return {};
                   })
         );
+        view.bind("juce_openURLInDefaultBrowser",
+                  wrapFn([editor](const choc::value::ValueView &args) -> choc::value::Value {
+                      auto url = args[0].getWithDefault("https://imagi.ro");
+                      return choc::value::Value(juce::URL(url).launchInDefaultBrowser());
+                  })
+        );
     }
 
     void WebViewManager::navigate(const std::string &url) {


### PR DESCRIPTION
It seems like there's no robust way in JavaScript of opening links in the system's default browser. Since juce::URL has a utility function for this, let's expose it to our webview.