### PR TITLE
Use the JUCE juce_gui_extra import

### DIFF
--- a/src/ChocBrowserComponent.h
+++ b/src/ChocBrowserComponent.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include "WebViewManager.h"
-#include "juce_gui_extra/embedding/juce_NSViewComponent.h"
-#include "juce_gui_extra/embedding/juce_HWNDComponent.h"
+#include <juce_gui_extra/juce_gui_extra.h>
 #if JUCE_WINDOWS
 #include "WinKeypressWorkaround.h"
 #endif


### PR DESCRIPTION
I'm not 100% why, but including `#include <juce_gui_extra/juce_gui_extra.h>` elsewhere in my project causes the following build-time error:

```
In file included from /Users/moechaieb/src/timeoffaudio/plugins/modules/juce/modules/juce_gui_extra/juce_gui_extra.h:108:
/Users/moechaieb/src/timeoffaudio/plugins/modules/juce/modules/juce_gui_extra/embedding/juce_NSViewComponent.h:44:17: error: redefinition of 'NSViewComponent'
class JUCE_API  NSViewComponent   : public Component
```

It seems like importing the header files directly for `juce_NSViewComponent.h` and `juce_HWNDComponent.h` doesn't use the necessary guards that will then cause the constants in those headers to be defined twice. Therefore, let's use the JUCE module header instead of singular class headers?